### PR TITLE
Include :deploy namespace in block example

### DIFF
--- a/docs/documentation/getting-started/before-after/index.markdown
+++ b/docs/documentation/getting-started/before-after/index.markdown
@@ -13,12 +13,14 @@ after :finishing, :notify
 
 
 # or define in block
-before :starting, :ensure_user do
-  #
-end
+namespace :deploy do
+  before :starting, :ensure_user do
+    #
+  end
 
-after :finishing, :notify do
-  #
+  after :finishing, :notify do
+    #
+  end
 end
 ```
 


### PR DESCRIPTION
### Summary

Small tweak to the documentation on before/after hooks.
